### PR TITLE
LRP-4919

### DIFF
--- a/release/_hotfix.sh
+++ b/release/_hotfix.sh
@@ -183,10 +183,10 @@ function compare_jars {
 			lc_log INFO ""
 
 			return 0
-		else
-			return 1
 		fi
 	fi
+
+	return 1
 }
 
 function copy_release_info_date {


### PR DESCRIPTION
Related issue: [LRP-4919](https://liferay.atlassian.net/browse/LRP-4919)
Some context to better understand the fix: bash doesn't care if you are not returning something for every possible outcome of the function, and in this case it's returning nothing and the function manage_jar is accepting "nothing" as true and is adding A LOT of files to the hotfix, and this is causing the giant size of the hotfix. If possible, please double check it.